### PR TITLE
Place amide H and carbonyl O from adjacent residues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 BioStructures = "4.7"
 DifferentiationInterface = "0.7.7"
 FiniteDifferences = "0.12.33"
+ForwardDiff = "1"
 LinearAlgebra = "1.0"
 Mooncake = "0.4.159"
 OrderedCollections = "1.8.1"
@@ -22,8 +23,9 @@ julia = "1.10.8"
 [extras]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DifferentiationInterface", "FiniteDifferences", "Mooncake", "Test"]
+test = ["DifferentiationInterface", "FiniteDifferences", "ForwardDiff", "Mooncake", "Test"]

--- a/extractdata/geometry.jl
+++ b/extractdata/geometry.jl
@@ -143,12 +143,16 @@ function parse_residue_graph(resname::AbstractString)
             sort!(quad[4])
         else
             a, b, c, d, tf = quad
-            if a === :HA
-                if c === :N && d === :H
-                    additions[i] = (:C, b, c, d, tf)
-                elseif c === :C && d === :O
-                    additions[i] = (:N, b, c, d, tf)
-                end
+            # H(i) is rigid with C(i-1) (both bonded to N(i)), not with any atom
+            # in residue i; O(i) is rigid with N(i+1) (both bonded to C(i)). A
+            # same-residue reference for either co-rotates with a dihedral that
+            # must leave them fixed (φ(i) for H, ψ(i) for O), so name the
+            # adjacent residue's atom using the CHARMM `-`/`+` convention;
+            # encode.jl resolves it against the neighboring residue.
+            if b === :CA && c === :N && d === :H
+                additions[i] = (Symbol("-C"), b, c, d, tf)
+            elseif b === :CA && c === :C && d === :O
+                additions[i] = (Symbol("+N"), b, c, d, tf)
             end
         end
     end
@@ -169,6 +173,8 @@ open(joinpath(dirname(@__DIR__), "src", "tables.jl"), "w") do io
     println(io, "# The pattern (a, b, c, [d1, d2, ...]) indicates that atoms d1, d2, ... are attached to b")
     println(io, "# The pattern (a, b, c, d, tf) indicates that atom d is attached to c; tf indicates whether the dihedral")
     println(io, "#   formed by a-b-c-d is rotatable (true) or fixed (false)")
+    println(io, "# A reference atom prefixed with \"-\" or \"+\" (e.g. \"-C\", \"+N\") names that atom in the previous or")
+    println(io, "#   next residue rather than the current one, following the CHARMM convention.")
     println(io, "const residue_build_sequence = Dict(")
     for resname in sort(collect(keys(BioStructures.residuedata)))
         resname ∉ generate_for_aas && continue

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -40,6 +40,32 @@ end
 Base.show(io::IO, bp::BondParametrization) = print(io, "BondParametrization with $(length(bp.atoms)) atoms and $(length(bp.residues)) residues")
 
 """
+    resatom, ridx = resolvebuildref(ref::AbstractString, i::Int, ress, resatomidxs)
+
+Resolve a build-step reference atom name `ref` for residue `ress[i]`.
+Standard names resolve within-residue. A name prefixed with `-` or `+`
+(e.g. `"-C"`, `"+N"`, the CHARMM convention) names an atom in the previous
+or next residue rather than in `ress[i]`.
+
+Returns the `Atom` together with its index into the coordinate array that
+`atomcoordinates` builds.
+"""
+function resolvebuildref(ref::AbstractString, i::Int, ress, resatomidxs)
+    c1 = ref[1]
+    if c1 == '-' || c1 == '+'
+        aname = ref[2:end]
+        j = c1 == '-' ? i - 1 : i + 1
+        ok = 1 <= j <= length(ress) && (c1 == '-' ? sequentialresidues(ress[j], ress[i]) : sequentialresidues(ress[i], ress[j]))
+        ok || error("residue $i ($(resname(ress[i]))): cannot resolve build-step reference \"$ref\" — " *
+                    (1 <= j <= length(ress) ? "residue $j is not sequential with residue $i (chain break)" :
+                     "residue $i has no " * (c1 == '-' ? "preceding" : "following") * " residue"))
+        return ress[j][aname], resatomidxs[j][aname]
+    else
+        return ress[i][ref], resatomidxs[i][ref]
+    end
+end
+
+"""
     bp, dihedrals = bondparametrization(chain)
 
 Parametrize a protein `chain` via bond parameters. Together, `bp` and
@@ -112,10 +138,13 @@ function bondparametrization(::Type{T}, chain::Chain) where {T<:Real}
                 if i == 1 && d == "H" && !haskey(res.atoms, "H")  # FIXME: this is a hack
                     d = "H2"
                 end
-                predecessors = (atomidx[a], atomidx[b], atomidx[c])
-                ℓcd = norm(res[c].coords - res[d].coords)
-                θbcd = bondangle(res[b], res[c], res[d])
-                ϕ = dihedralangle(res[a], res[b], res[c], res[d])
+                atomA, idxA = resolvebuildref(a, i, ress, resatomidxs)
+                atomB, idxB = resolvebuildref(b, i, ress, resatomidxs)
+                atomC, idxC = resolvebuildref(c, i, ress, resatomidxs)
+                predecessors = (idxA, idxB, idxC)
+                ℓcd = norm(atomC.coords - res[d].coords)
+                θbcd = bondangle(atomB, atomC, res[d])
+                ϕ = dihedralangle(atomA, atomB, atomC, res[d])
                 push!(steps, Extend{T}(predecessors, ℓcd, θbcd, rotatable, ϕ))
                 if rotatable
                     push!(dihedrals, ϕ)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -4,13 +4,15 @@
 # The pattern (a, b, c, [d1, d2, ...]) indicates that atoms d1, d2, ... are attached to b
 # The pattern (a, b, c, d, tf) indicates that atom d is attached to c; tf indicates whether the dihedral
 #   formed by a-b-c-d is rotatable (true) or fixed (false)
+# A reference atom prefixed with "-" or "+" (e.g. "-C", "+N") names that atom in the previous or
+#   next residue rather than the current one, following the CHARMM convention.
 const residue_build_sequence = Dict(
     "ALA" => [
             ("C", "CA", "N", ["CB", "HA"]),
             ("C", "CA", "CB", "HB1", true),
             ("CA", "CB", "HB1", ["HB2", "HB3"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "ARG" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -24,8 +26,8 @@ const residue_build_sequence = Dict(
             ("CD", "NE", "CZ", ["HE"]),
             ("CD", "NE", "CZ", "NH1", true),
             ("NE", "CZ", "NH1", ["NH2"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
             ("NE", "CZ", "NH2", "HH22", false),
             ("CZ", "NH2", "HH22", ["HH21"]),
             ("NE", "CZ", "NH1", "HH11", false),
@@ -39,8 +41,8 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "OD1", ["ND2"]),
             ("CB", "CG", "ND2", "HD21", true),
             ("CG", "ND2", "HD21", ["HD22"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "ASP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -48,8 +50,8 @@ const residue_build_sequence = Dict(
             ("CA", "CB", "CG", ["HB2", "HB3"]),
             ("CA", "CB", "CG", "OD1", true),
             ("CB", "CG", "OD1", ["OD2"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CALA" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -57,7 +59,7 @@ const residue_build_sequence = Dict(
             ("CA", "C", "OXT", ["O"]),
             ("C", "CA", "CB", "HB1", true),
             ("CA", "CB", "HB1", ["HB2", "HB3"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CARG" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -73,7 +75,7 @@ const residue_build_sequence = Dict(
             ("NE", "CZ", "NH1", ["NH2"]),
             ("CB", "CA", "C", "OXT", true),
             ("CA", "C", "OXT", ["O"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
             ("NE", "CZ", "NH2", "HH22", false),
             ("CZ", "NH2", "HH22", ["HH21"]),
             ("NE", "CZ", "NH1", "HH11", false),
@@ -89,7 +91,7 @@ const residue_build_sequence = Dict(
             ("CA", "C", "OXT", ["O"]),
             ("CB", "CG", "ND2", "HD21", true),
             ("CG", "ND2", "HD21", ["HD22"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CASP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -99,7 +101,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "OD1", ["OD2"]),
             ("CB", "CA", "C", "OXT", true),
             ("CA", "C", "OXT", ["O"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CCYS" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -108,7 +110,7 @@ const residue_build_sequence = Dict(
             ("C", "CA", "CB", "SG", true),
             ("CA", "CB", "SG", ["HB2", "HB3"]),
             ("CA", "CB", "SG", "HG", true),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CGLN" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -122,7 +124,7 @@ const residue_build_sequence = Dict(
             ("CA", "C", "OXT", ["O"]),
             ("CG", "CD", "NE2", "HE21", true),
             ("CD", "NE2", "HE21", ["HE22"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CGLU" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -134,13 +136,13 @@ const residue_build_sequence = Dict(
             ("CG", "CD", "OE1", ["OE2"]),
             ("CB", "CA", "C", "OXT", true),
             ("CA", "C", "OXT", ["O"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CGLY" => [
             ("C", "CA", "N", ["HA2", "HA3"]),
             ("N", "CA", "C", "OXT", true),
             ("CA", "C", "OXT", ["O"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CHID" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -155,7 +157,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "CD2", "NE2", false),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CHIE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -170,7 +172,7 @@ const residue_build_sequence = Dict(
             ("CD2", "NE2", "CE1", ["HE2"]),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CHIP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -186,7 +188,7 @@ const residue_build_sequence = Dict(
             ("CD2", "NE2", "CE1", ["HE2"]),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CILE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -200,7 +202,7 @@ const residue_build_sequence = Dict(
             ("CG1", "CD1", "HD11", ["HD12", "HD13"]),
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CLEU" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -214,7 +216,7 @@ const residue_build_sequence = Dict(
             ("CG", "CD2", "HD21", ["HD22", "HD23"]),
             ("CB", "CG", "CD1", "HD11", true),
             ("CG", "CD1", "HD11", ["HD12", "HD13"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CLYS" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -230,7 +232,7 @@ const residue_build_sequence = Dict(
             ("CA", "C", "OXT", ["O"]),
             ("CD", "CE", "NZ", "HZ1", true),
             ("CE", "NZ", "HZ1", ["HZ2", "HZ3"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CMET" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -243,7 +245,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "SD", "CE", true),
             ("CG", "SD", "CE", "HE1", true),
             ("SD", "CE", "HE1", ["HE2", "HE3"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CPHE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -261,7 +263,7 @@ const residue_build_sequence = Dict(
             ("CD2", "CE2", "CZ", ["HE2"]),
             ("CE1", "CZ", "CE2", ["HZ"]),
             ("CD1", "CE1", "CZ", ["HE1"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CPRO" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -280,7 +282,7 @@ const residue_build_sequence = Dict(
             ("CB", "CA", "C", "OXT", true),
             ("CA", "C", "OXT", ["O"]),
             ("CA", "CB", "OG", "HG", true),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CTHR" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -291,7 +293,7 @@ const residue_build_sequence = Dict(
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
             ("CA", "CB", "OG1", "HG1", true),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CTRP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -313,7 +315,7 @@ const residue_build_sequence = Dict(
             ("CD2", "CE2", "CZ2", ["NE1"]),
             ("CG", "CD1", "NE1", ["HD1"]),
             ("CD1", "NE1", "CE2", ["HE1"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CTYR" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -332,7 +334,7 @@ const residue_build_sequence = Dict(
             ("CE1", "CZ", "CE2", ["OH"]),
             ("CD1", "CE1", "CZ", ["HE1"]),
             ("CE1", "CZ", "OH", "HH", true),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CVAL" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -344,15 +346,15 @@ const residue_build_sequence = Dict(
             ("CB", "CG1", "HG11", ["HG12", "HG13"]),
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
-            ("C", "CA", "N", "H", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "CYS" => [
             ("C", "CA", "N", ["CB", "HA"]),
             ("C", "CA", "CB", "SG", true),
             ("CA", "CB", "SG", ["HB2", "HB3"]),
             ("CA", "CB", "SG", "HG", true),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "GLN" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -364,8 +366,8 @@ const residue_build_sequence = Dict(
             ("CG", "CD", "OE1", ["NE2"]),
             ("CG", "CD", "NE2", "HE21", true),
             ("CD", "NE2", "HE21", ["HE22"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "GLU" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -375,13 +377,13 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "CD", ["HG2", "HG3"]),
             ("CB", "CG", "CD", "OE1", true),
             ("CG", "CD", "OE1", ["OE2"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "GLY" => [
             ("C", "CA", "N", ["HA2", "HA3"]),
-            ("N", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "HID" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -394,8 +396,8 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "CD2", "NE2", false),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "HIE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -408,8 +410,8 @@ const residue_build_sequence = Dict(
             ("CD2", "NE2", "CE1", ["HE2"]),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "HIP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -423,8 +425,8 @@ const residue_build_sequence = Dict(
             ("CD2", "NE2", "CE1", ["HE2"]),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "ILE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -436,8 +438,8 @@ const residue_build_sequence = Dict(
             ("CG1", "CD1", "HD11", ["HD12", "HD13"]),
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "LEU" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -449,8 +451,8 @@ const residue_build_sequence = Dict(
             ("CG", "CD2", "HD21", ["HD22", "HD23"]),
             ("CB", "CG", "CD1", "HD11", true),
             ("CG", "CD1", "HD11", ["HD12", "HD13"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "LYS" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -464,8 +466,8 @@ const residue_build_sequence = Dict(
             ("CD", "CE", "NZ", ["HE2", "HE3"]),
             ("CD", "CE", "NZ", "HZ1", true),
             ("CE", "NZ", "HZ1", ["HZ2", "HZ3"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "MET" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -476,8 +478,8 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "SD", "CE", true),
             ("CG", "SD", "CE", "HE1", true),
             ("SD", "CE", "HE1", ["HE2", "HE3"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "NALA" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -485,7 +487,7 @@ const residue_build_sequence = Dict(
             ("CA", "N", "H2", ["H1", "H3"]),
             ("C", "CA", "CB", "HB1", true),
             ("CA", "CB", "HB1", ["HB2", "HB3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NARG" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -501,7 +503,7 @@ const residue_build_sequence = Dict(
             ("NE", "CZ", "NH1", ["NH2"]),
             ("C", "CA", "N", "H2", true),
             ("CA", "N", "H2", ["H1", "H3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
             ("NE", "CZ", "NH2", "HH22", false),
             ("CZ", "NH2", "HH22", ["HH21"]),
             ("NE", "CZ", "NH1", "HH11", false),
@@ -517,7 +519,7 @@ const residue_build_sequence = Dict(
             ("CA", "N", "H2", ["H1", "H3"]),
             ("CB", "CG", "ND2", "HD21", true),
             ("CG", "ND2", "HD21", ["HD22"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NASP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -527,7 +529,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "OD1", ["OD2"]),
             ("C", "CA", "N", "H2", true),
             ("CA", "N", "H2", ["H1", "H3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NCYS" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -536,7 +538,7 @@ const residue_build_sequence = Dict(
             ("C", "CA", "N", "H2", true),
             ("CA", "N", "H2", ["H1", "H3"]),
             ("CA", "CB", "SG", "HG", true),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NGLN" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -550,7 +552,7 @@ const residue_build_sequence = Dict(
             ("CA", "N", "H2", ["H1", "H3"]),
             ("CG", "CD", "NE2", "HE21", true),
             ("CD", "NE2", "HE21", ["HE22"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NGLU" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -562,13 +564,13 @@ const residue_build_sequence = Dict(
             ("CG", "CD", "OE1", ["OE2"]),
             ("C", "CA", "N", "H2", true),
             ("CA", "N", "H2", ["H1", "H3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NGLY" => [
             ("C", "CA", "N", ["HA2", "HA3"]),
             ("C", "CA", "N", "H2", true),
             ("CA", "N", "H2", ["H1", "H3"]),
-            ("N", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NHID" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -583,7 +585,7 @@ const residue_build_sequence = Dict(
             ("CG", "ND1", "CE1", "NE2", false),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NHIE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -598,7 +600,7 @@ const residue_build_sequence = Dict(
             ("CD2", "NE2", "CE1", ["HE2"]),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NHIP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -614,7 +616,7 @@ const residue_build_sequence = Dict(
             ("CD2", "NE2", "CE1", ["HE2"]),
             ("CG", "CD2", "NE2", ["HD2"]),
             ("ND1", "CE1", "NE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NILE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -628,7 +630,7 @@ const residue_build_sequence = Dict(
             ("CG1", "CD1", "HD11", ["HD12", "HD13"]),
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NLEU" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -642,7 +644,7 @@ const residue_build_sequence = Dict(
             ("CG", "CD2", "HD21", ["HD22", "HD23"]),
             ("CB", "CG", "CD1", "HD11", true),
             ("CG", "CD1", "HD11", ["HD12", "HD13"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NLYS" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -658,7 +660,7 @@ const residue_build_sequence = Dict(
             ("CA", "N", "H2", ["H1", "H3"]),
             ("CD", "CE", "NZ", "HZ1", true),
             ("CE", "NZ", "HZ1", ["HZ2", "HZ3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NMET" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -671,7 +673,7 @@ const residue_build_sequence = Dict(
             ("CA", "N", "H2", ["H1", "H3"]),
             ("CG", "SD", "CE", "HE1", true),
             ("SD", "CE", "HE1", ["HE2", "HE3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NPHE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -689,7 +691,7 @@ const residue_build_sequence = Dict(
             ("CD2", "CE2", "CZ", ["HE2"]),
             ("CE1", "CZ", "CE2", ["HZ"]),
             ("CD1", "CE1", "CZ", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NPRO" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -699,7 +701,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG", "CD", ["HG2", "HG3"]),
             ("CA", "CB", "CG", ["HB2", "HB3"]),
             ("CG", "CD", "N", ["HD2", "HD3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NSER" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -708,7 +710,7 @@ const residue_build_sequence = Dict(
             ("C", "CA", "N", "H2", true),
             ("CA", "N", "H2", ["H1", "H3"]),
             ("CA", "CB", "OG", "HG", true),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NTHR" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -719,7 +721,7 @@ const residue_build_sequence = Dict(
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
             ("CA", "CB", "OG1", "HG1", true),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NTRP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -741,7 +743,7 @@ const residue_build_sequence = Dict(
             ("CD2", "CE2", "CZ2", ["NE1"]),
             ("CG", "CD1", "NE1", ["HD1"]),
             ("CD1", "NE1", "CE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NTYR" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -760,7 +762,7 @@ const residue_build_sequence = Dict(
             ("CE1", "CZ", "CE2", ["OH"]),
             ("CD1", "CE1", "CZ", ["HE1"]),
             ("CE1", "CZ", "OH", "HH", true),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "NVAL" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -772,7 +774,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG1", "HG11", ["HG12", "HG13"]),
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "PHE" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -788,8 +790,8 @@ const residue_build_sequence = Dict(
             ("CD2", "CE2", "CZ", ["HE2"]),
             ("CE1", "CZ", "CE2", ["HZ"]),
             ("CD1", "CE1", "CZ", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "PRO" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -798,15 +800,15 @@ const residue_build_sequence = Dict(
             ("CA", "CB", "CG", ["HB2", "HB3"]),
             ("CG", "CD", "N", ["HD2", "HD3"]),
             ("CB", "CG", "CD", ["HG2", "HG3"]),
-            ("CB", "CA", "C", "O", false),
+            ("+N", "CA", "C", "O", false),
         ],
     "SER" => [
             ("C", "CA", "N", ["CB", "HA"]),
             ("C", "CA", "CB", "OG", true),
             ("CA", "CB", "OG", ["HB2", "HB3"]),
             ("CA", "CB", "OG", "HG", true),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "THR" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -815,8 +817,8 @@ const residue_build_sequence = Dict(
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
             ("CA", "CB", "OG1", "HG1", true),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "TRP" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -836,8 +838,8 @@ const residue_build_sequence = Dict(
             ("CD2", "CE2", "CZ2", ["NE1"]),
             ("CG", "CD1", "NE1", ["HD1"]),
             ("CD1", "NE1", "CE2", ["HE1"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "TYR" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -854,8 +856,8 @@ const residue_build_sequence = Dict(
             ("CE1", "CZ", "CE2", ["OH"]),
             ("CD1", "CE1", "CZ", ["HE1"]),
             ("CE1", "CZ", "OH", "HH", true),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
     "VAL" => [
             ("C", "CA", "N", ["CB", "HA"]),
@@ -865,7 +867,7 @@ const residue_build_sequence = Dict(
             ("CB", "CG1", "HG11", ["HG12", "HG13"]),
             ("CA", "CB", "CG2", "HG21", true),
             ("CB", "CG2", "HG21", ["HG22", "HG23"]),
-            ("CB", "CA", "C", "O", false),
-            ("C", "CA", "N", "H", false),
+            ("+N", "CA", "C", "O", false),
+            ("-C", "CA", "N", "H", false),
         ],
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DihedralParametrization
 using BioStructures
 using StaticArrays
 using LinearAlgebra
+using ForwardDiff
 using Test
 
 const testad = Base.VERSION.major == 1 && Base.VERSION.minor == 10
@@ -39,6 +40,120 @@ end
             at = chain[adata.ridx][String(adata.aname)]
             @test isapprox(at.coords, coords; atol=1e-8)
         end
+    end
+
+    @testset "Bond lengths and angles are invariant under every dihedral" begin
+        # The parametrization's defining contract: reconstructing at any
+        # dihedral vector must leave every bond length and every bond angle
+        # fixed at its encoded value, since only the dihedrals themselves are
+        # free parameters. This must hold across residue boundaries too --
+        # C(i)-N(i+1), O(i)-C(i)-N(i+1), C(i)-N(i+1)-CA(i+1), and
+        # C(i)-N(i+1)-H(i+1) -- since a same-residue build reference for H(i)
+        # or O(i) would let it co-rotate with φ(i) or ψ(i) instead of staying
+        # fixed. A test that only looked at same-residue geometry would pass
+        # vacuously.
+        path = joinpath(@__DIR__, "data", "AF-M3YHX5-F1-model_v4_hydrogens.cif")
+        struc = read(path, MMCIFFormat)
+        specializeresnames!(struc)
+        chain = only(only(struc))
+        ress = collectresidues(chain)
+        nres = length(ress)
+        bp, dihedrals = bondparametrization(chain)
+
+        X0 = atomcoordinates(bp, dihedrals, chain)
+        for (adata, coords) in zip(bp.atoms, X0)
+            at = chain[adata.ridx][String(adata.aname)]
+            @test isapprox(at.coords, coords; atol=1e-8)
+        end
+
+        natoms = length(X0)
+        anames = [String(a.aname) for a in bp.atoms]
+        ridx = [a.ridx for a in bp.atoms]
+
+        # Connectivity comes from BioStructures' residue templates, which give
+        # each residue's intra-residue bonds plus the atoms carrying bonds to
+        # adjacent residues. Deriving it from interatomic distances instead
+        # would need element-dependent cutoffs (S-H is ~1.34 Å against C-H's
+        # ~1.09 Å) and would still have to special-case geminal H pairs.
+        atomrow = Dict((a.ridx, String(a.aname)) => k for (k, a) in pairs(bp.atoms))
+        bonds = Tuple{Int,Int}[]
+        for res in ress
+            rd = BioStructures.residuedata[resname(res)]
+            for (n1, n2) in rd.bonds
+                (haskey(res.atoms, n1) && haskey(res.atoms, n2)) || continue
+                push!(bonds, (atomrow[(resnumber(res), n1)], atomrow[(resnumber(res), n2)]))
+            end
+        end
+        for i = 1:nres-1     # peptide bonds
+            push!(bonds, (atomrow[(resnumber(ress[i]), "C")], atomrow[(resnumber(ress[i+1]), "N")]))
+        end
+        nbrs = [Int[] for _ = 1:natoms]
+        for (i, j) in bonds
+            push!(nbrs[i], j)
+            push!(nbrs[j], i)
+        end
+        angles = Tuple{Int,Int,Int}[]
+        for b = 1:natoms, ii in eachindex(nbrs[b]), jj = ii+1:length(nbrs[b])
+            push!(angles, (nbrs[b][ii], b, nbrs[b][jj]))
+        end
+
+        # Confirm the topology actually reaches the cross-residue quartets
+        # where the documented violations live.
+        crossbond(i, j) = ridx[i] != ridx[j]
+        crosstriple(a, b, c) = ridx[a] != ridx[b] || ridx[b] != ridx[c]
+        namematch(i, j, n1, n2) = (anames[i] == n1 && anames[j] == n2) || (anames[i] == n2 && anames[j] == n1)
+        nCN = count(((i, j),) -> crossbond(i, j) && namematch(i, j, "C", "N"), bonds)
+        nONC = count(((a, b, c),) -> crosstriple(a, b, c) && anames[b] == "C" && namematch(a, c, "O", "N"), angles)
+        nCNH = count(((a, b, c),) -> crosstriple(a, b, c) && anames[b] == "N" && namematch(a, c, "C", "H"), angles)
+        nCNCA = count(((a, b, c),) -> crosstriple(a, b, c) && anames[b] == "N" && namematch(a, c, "C", "CA"), angles)
+        @test nCN == nres - 1
+        @test nONC == nres - 1
+        @test nCNCA == nres - 1
+        # Proline's ring nitrogen carries no amide H, so C(i)-N(i+1)-H(i+1)
+        # exists only where residue i+1 has one.
+        @test nCNH == count(i -> haskey(ress[i].atoms, "H"), 2:nres)
+
+        # ∂(bond length)/∂θ_k and ∂(bond angle)/∂θ_k for every bond, angle,
+        # and dihedral index k, from a single ForwardDiff pass over the
+        # reconstruction. Any nonzero entry is a violation of the invariance
+        # contract. These derivatives are a detector, not a magnitude: at a
+        # planar amide a misplaced H or O sits at a local extremum of its
+        # spurious rotation, so the angle derivative can read ~0.04 deg/rad
+        # while the atom itself moves ~1 Å/rad. Any nonzero entry is a bug;
+        # its size says little about how far the atom strays.
+        function internal_coords(dih)
+            X = atomcoordinates(bp, dih, chain)
+            ls = [norm(X[i] - X[j]) for (i, j) in bonds]
+            as = [bondangle(X[a] - X[b], X[c] - X[b]) for (a, b, c) in angles]
+            return vcat(ls, as)
+        end
+        J = ForwardDiff.jacobian(internal_coords, dihedrals)
+        nbonds = length(bonds)
+        tol = 1e-8
+        sensitive(k) = maximum(abs, @view J[k, :]) > tol
+
+        # Proline's sidechain closes a ring back onto N, but the build sequence
+        # is a tree: CB is placed from (C, CA, N) while CG is reached the long
+        # way round through CD, so nothing holds the CB-CG closure. The ring
+        # dihedrals are consequently not free, and the coordinates spanning the
+        # closure are not invariant.
+        resnameof = Dict(resnumber(r) => resname(r) for r in ress)
+        ringatoms = ("CB", "CG", "CD", "HB2", "HB3", "HG2", "HG3", "HD2", "HD3")
+        inprolinering(k) = resnameof[ridx[k]] == "PRO" && anames[k] in ringatoms
+        touchesring(t) = any(inprolinering, t)
+
+        badlengths = count(k -> !touchesring(bonds[k]) && sensitive(k), 1:nbonds)
+        badangles = count(k -> !touchesring(angles[k-nbonds]) && sensitive(k), nbonds+1:size(J, 1))
+        @test badlengths == 0
+        @test badangles == 0
+
+        # The proline ring closure itself. Marked broken rather than skipped so
+        # the gap is visible: PRO's ("C","CA","N","CD") and ("CA","N","CD","CG")
+        # steps are flagged rotatable, which promises degrees of freedom the
+        # ring does not actually have.
+        prolineCBCG = [k for k = 1:nbonds if namematch(bonds[k]..., "CB", "CG") && resnameof[ridx[bonds[k][1]]] == "PRO"]
+        @test length(prolineCBCG) == count(r -> resname(r) == "PRO", ress)
+        @test_broken !any(sensitive, prolineCBCG)
     end
 
     if testad


### PR DESCRIPTION
The backbone amide H(i) is rigid with C(i-1), and the carbonyl O(i) is rigid with N(i+1); neither is rigid with any atom of residue i alone. A same-residue reference for either is measured about the very axis that phi(i) or psi(i) rotates about, so it is not a constant of the parametrization: pinning it dragged H out of the amide plane with phi, and sheared O away from N(i+1) with psi. Reconstruction at the encoded dihedrals was unaffected, since the reference dihedral is read from the input structure, so the error surfaced only in derivatives and in conformational search.

A build step may now name an atom in the previous or next residue using the CHARMM "-C"/"+N" convention. encode.jl resolves such a reference against the neighboring residue, and errors at a chain terminus or a resnumber discontinuity rather than silently substituting an atom. The entire backbone is built before any sidechain step, so a referenced neighbor atom is always already placed.

The accompanying test asserts the defining invariant directly: every bond length and every bond angle has zero derivative with respect to every dihedral. Connectivity comes from BioStructures' residue templates and spans residue boundaries, which is where the two violations lived and where a same-residue topology would pass vacuously.

Proline is exempted and its ring closure marked broken. Its sidechain returns to N, but the build sequence is a tree: CB is placed from (C, CA, N) while CG is reached the long way round through CD, so nothing holds the CB-CG closure. Its ring dihedrals are flagged rotatable, promising freedom the closed ring does not have.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>